### PR TITLE
fix: extract and unescape content before rendering

### DIFF
--- a/src/markdown/utils.ts
+++ b/src/markdown/utils.ts
@@ -3,6 +3,8 @@
 
 const HTML_ESCAPE_TEST_RE = /[&<>"]/
 const HTML_ESCAPE_REPLACE_RE = /[&<>"]/g
+const HTML_UNESCAPE_TEST_RE = /&(?:amp|lt|gt|quot|#39|#34);/;
+const HTML_UNESCAPE_REPLACE_RE = /&(?:amp|lt|gt|quot|#39|#34);/g;
 
 function replaceUnsafeChar(ch: string): string {
     switch (ch) {
@@ -18,9 +20,35 @@ function replaceUnsafeChar(ch: string): string {
     return ""
 }
 
+
+function replaceEscapedChar(entity: string): string {
+    switch (entity) {
+      case "&amp;":
+        return "&";
+      case "&lt;":
+        return "<";
+      case "&gt;":
+        return ">";
+      case "&quot;":
+        return '"';
+      case "&#39;":
+        return "'";
+      case "&#34;":
+        return '"';
+    }
+    return "";
+  }
+
 export function escapeHtml(str: string): string {
     if (HTML_ESCAPE_TEST_RE.test(str)) {
         return str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar)
     }
     return str
 }
+
+export function reverseEscapeHtml(str: string): string {
+    if (HTML_UNESCAPE_TEST_RE.test(str)) {
+      return str.replace(HTML_UNESCAPE_REPLACE_RE, replaceEscapedChar);
+    }
+    return str;
+  }  


### PR DESCRIPTION
# This Pull request:
Extracted `div#publish-page` to isolate the markdown content instead of processing the entire HTML page. Introduced `reverseEscapeHtml` to handle already escaped characters in the fetched content, preventing double escaping when rendered.

## Changes or fixes:

- Extract only the markdown content from `div#publish-page` before rendering.

- Implement `reverseEscapeHtml` to prevent double escaping.

## Checklist:

- [x] Pass all tests
- [x] Pass the lint

This PR fixes  #49 